### PR TITLE
fix: :bug: Added padding to appgroup and border styling to colortab

### DIFF
--- a/client/packages/portal-client/src/components/portal-menu/PortalMenu.tsx
+++ b/client/packages/portal-client/src/components/portal-menu/PortalMenu.tsx
@@ -39,7 +39,7 @@ const styles = {
 	`,
 	appsWrapper: (count: number) => css`
 		padding: 0 0 1rem 1rem;
-		height: 600px;
+		height: 650px;
 		display: block;
 		grid-template-columns: auto;
 		padding-bottom: 2rem;

--- a/client/packages/portal-ui/src/lib/portal-menu/group/ColorTab.tsx
+++ b/client/packages/portal-ui/src/lib/portal-menu/group/ColorTab.tsx
@@ -1,3 +1,3 @@
 export const ColorTab = ({ color }: { color: string }) => {
-	return <div style={{ height: '16px', width: '6px', backgroundColor: color }}></div>;
+	return <div style={{ height: '15px', width: '10px', borderRadius: '5px' ,backgroundColor: color}}></div>;
 };

--- a/client/packages/portal-ui/src/lib/portal-menu/styles.ts
+++ b/client/packages/portal-ui/src/lib/portal-menu/styles.ts
@@ -40,7 +40,7 @@ export const styles = {
 		width: 100%;
 		align-items: flex-start;
 		break-inside: avoid;
-		margin-bottom: 1rem;
+		margin-bottom: 2rem;
 	`,
 	list: css`
 		display: flex;


### PR DESCRIPTION
# Description

Small tweak to padding on appgroup. 
Added borderradius to colortab to align better with figma design

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Documentation and comments is added where needed.
- [x] UX has reviewed relevant UI contributions.


## Definition of Done
- [x] PR title and description are to the point and understandable
- [x] I have performed a self-review of my own code
