### PR TITLE
feat: added /metrics controller endpoint used for Radix

### DIFF
--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/Controllers/MetricsController.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/Controllers/MetricsController.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace Equinor.ProjectExecutionPortal.WebApi.Controllers
+{
+    [ApiController]
+    [Route("metrics")]
+    public class MetricsController : ControllerBase
+    {
+        // Radix calls this endpoint when monitoring is true in radixconfig.yaml
+        // For now, just return Ok to avoid it triggering a failed request in app insights
+        // Can later consider if we need more exciting metrics, see the following link for more info:
+        // - https://www.radix.equinor.com/guides/monitoring/#metrics-visualisation
+
+        [HttpGet]
+        public IActionResult GetMetrics()
+        {
+            return Ok();
+        }
+    }
+}

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/Controllers/MetricsController.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/Controllers/MetricsController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Equinor.ProjectExecutionPortal.WebApi.Controllers
 {
@@ -12,6 +13,7 @@ namespace Equinor.ProjectExecutionPortal.WebApi.Controllers
         // - https://www.radix.equinor.com/guides/monitoring/#metrics-visualisation
 
         [HttpGet]
+        [AllowAnonymous]
         public IActionResult GetMetrics()
         {
             return Ok();


### PR DESCRIPTION
# Description

Radix automatically polls /metrics endpoint for health checks. This endpoint is not set up, thus resulting in a lot of 404 errors in Application Insights.

Solution: For now, implement a basic endpoint that returns OK. Later we can consider adding custom metrics.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Documentation and comments is added where needed.
- [ ] My code is covered by tests.
- [x] UX has reviewed relevant UI contributions.


## Definition of Done
- [x] PR title and description are to the point and understandable
- [x] I have performed a self-review of my own code
