### PR TITLE
fix: fixing context navigation when context is not onboarded

### DIFF
--- a/client/packages/portal-client/src/components/context/HasContext.tsx
+++ b/client/packages/portal-client/src/components/context/HasContext.tsx
@@ -8,4 +8,5 @@ export const HasContext = () => {
 	if (isContextLoading) return null;
 
 	if (!hasContext) return <Navigate to="/" />;
+	return null;
 };

--- a/client/packages/portal-client/src/components/context/HasContext.tsx
+++ b/client/packages/portal-client/src/components/context/HasContext.tsx
@@ -1,0 +1,11 @@
+import { useOnboardedContexts } from '@equinor/portal-core';
+import { Navigate } from 'react-router-dom';
+
+/** This component will navigate you to root if context is not onboarded */
+export const HasContext = () => {
+	const { hasContext, isLoading: isContextLoading } = useOnboardedContexts();
+
+	if (isContextLoading) return null;
+
+	if (!hasContext) return <Navigate to="/" />;
+};

--- a/client/packages/portal-client/src/components/portal-frame/PortalFrame.tsx
+++ b/client/packages/portal-client/src/components/portal-frame/PortalFrame.tsx
@@ -1,4 +1,4 @@
-import { MenuProvider, ViewProvider, useOnboardedContexts } from '@equinor/portal-core';
+import { MenuProvider, ViewProvider } from '@equinor/portal-core';
 import { StyleProvider } from '@equinor/portal-ui';
 import { NotificationService, ServiceMessageProvider } from '@equinor/service-message';
 import { Outlet } from 'react-router-dom';

--- a/client/packages/portal-client/src/components/portal-frame/PortalFrame.tsx
+++ b/client/packages/portal-client/src/components/portal-frame/PortalFrame.tsx
@@ -1,4 +1,4 @@
-import { MenuProvider, ViewProvider } from '@equinor/portal-core';
+import { MenuProvider, ViewProvider, useOnboardedContexts } from '@equinor/portal-core';
 import { StyleProvider } from '@equinor/portal-ui';
 import { NotificationService, ServiceMessageProvider } from '@equinor/service-message';
 import { Outlet } from 'react-router-dom';
@@ -8,6 +8,7 @@ import { MenuGroups } from '../portal-menu/PortalMenu';
 import { PortalSideSheet } from '../portal-side-sheet';
 import { useBookmarkNavigate } from '@equinor/fusion-framework-react-module-bookmark/portal';
 import { BookmarkProvider } from '@equinor/fusion-framework-react-components-bookmark';
+import { HasContext } from '../context/HasContext';
 
 export const PortalFrame = () => {
 	useBookmarkNavigate({ resolveAppPath: (appKey: string) => `/apps/${appKey}` });
@@ -22,6 +23,7 @@ export const PortalFrame = () => {
 								<MenuProvider>
 									<MainHeader />
 									<MenuGroups />
+									<HasContext />
 									<Outlet />
 								</MenuProvider>
 							</ViewProvider>

--- a/client/packages/portal-core/src/framework-configurator/portal-context-configurators.ts
+++ b/client/packages/portal-core/src/framework-configurator/portal-context-configurators.ts
@@ -9,12 +9,10 @@ const CONTEXT_SOCAGE_KEY = 'context';
 export function storeCurrentContext(contextProvider: IContextProvider) {
 	contextProvider.currentContext$.subscribe((context) => {
 		if (context?.title === 'Unexpected error' || !context?.id || !context) {
-			storage.removeItem(CONTEXT_SOCAGE_KEY);
 			return;
 		}
 
 		const storedContextId = storage.getItem<string>(CONTEXT_SOCAGE_KEY);
-
 		// Update the history with the current context selected.
 		setContextHistory(context);
 
@@ -24,16 +22,25 @@ export function storeCurrentContext(contextProvider: IContextProvider) {
 	});
 }
 
+export function clearLocalContext() {
+	storage.removeItem(CONTEXT_SOCAGE_KEY);
+}
+
+export function validateLocalContext(contextId: string): boolean {
+	const storedContextId = storage.getItem<string>(CONTEXT_SOCAGE_KEY);
+	return contextId === storedContextId;
+}
+
 export function setStoredContext(contextProvider: IContextProvider) {
 	const storedContextId = storage.getItem<string>(CONTEXT_SOCAGE_KEY);
+
+	const uriContext = getContextFormUrl();
 
 	if (storedContextId && window.location.pathname === '/') {
 		window.location.replace(`project/${storedContextId}`);
 	}
 
-	const uriContext = getContextFormUrl();
-
-	if (contextProvider.currentContext?.id !== storedContextId || (uriContext && uriContext[0] !== storedContextId)) {
+	if (contextProvider.currentContext?.id !== storedContextId || uriContext) {
 		contextProvider.contextClient.setCurrentContext(uriContext ? uriContext : storedContextId);
 	}
 }

--- a/client/packages/portal-core/src/hooks/use-context-resolver.ts
+++ b/client/packages/portal-core/src/hooks/use-context-resolver.ts
@@ -4,6 +4,7 @@ import { useCallback } from 'react';
 import { getContextHistory } from '../framework-configurator/portal-context-history';
 import { useContextClient } from './use-context-client';
 import { useFrameworkContext } from './use-framework-context';
+import { clearLocalContext } from '../framework-configurator';
 
 export const useContextResolver = (type: string[]): ContextResolver => {
 	const contextProvider = useFrameworkContext();
@@ -79,6 +80,7 @@ export const useContextResolver = (type: string[]): ContextResolver => {
 		closeHandler: (e: MouseEvent) => {
 			e.stopPropagation();
 			contextProvider.clearCurrentContext();
+			clearLocalContext();
 		},
 	};
 };

--- a/client/packages/portal-core/src/hooks/use-onboarded-contexts.ts
+++ b/client/packages/portal-core/src/hooks/use-onboarded-contexts.ts
@@ -1,18 +1,21 @@
+import { clearLocalContext } from '../framework-configurator';
 import { useOnboardedContextsQuery } from '../queries';
 import { useFrameworkContext } from './use-framework-context';
 
 import { useFrameworkCurrentContext } from './use-framework-current-context';
 
 export const useOnboardedContexts = () => {
-	const { data } = useOnboardedContextsQuery();
+	const { data, isLoading } = useOnboardedContextsQuery();
 	const contextProvider = useFrameworkContext();
 	const currentContext = useFrameworkCurrentContext();
 
 	const clearContext = () => {
 		contextProvider.clearCurrentContext();
+		clearLocalContext();
 	};
 
 	return {
+		isLoading,
 		onboardedContexts: data,
 		hasContext: Boolean(
 			data?.find((context) => context.externalId === currentContext?.externalId) || !currentContext

--- a/client/packages/portal-core/tsconfig.json
+++ b/client/packages/portal-core/tsconfig.json
@@ -12,6 +12,6 @@
     "noFallthroughCasesInSwitch": true,
   },
   "files": [],
-  "include": [],
+  "include": ["**/*.tsx"]
 
 }

--- a/client/packages/portal-pages/src/pages/project-page/ProjectPage.tsx
+++ b/client/packages/portal-pages/src/pages/project-page/ProjectPage.tsx
@@ -1,4 +1,4 @@
-import { useFrameworkCurrentContext, useOnboardedContexts } from '@equinor/portal-core';
+import { useFrameworkCurrentContext } from '@equinor/portal-core';
 import { WorkAssigned } from '@equinor/portal-ui';
 import { Navigate, useParams } from 'react-router-dom';
 
@@ -22,7 +22,6 @@ export const ProjectPage = () => {
 	const { contextId } = useParams();
 
 	const currentContext = useFrameworkCurrentContext<ProjectMaster>();
-	const { hasContext } = useOnboardedContexts();
 
 	if (
 		!currentContext ||
@@ -31,7 +30,7 @@ export const ProjectPage = () => {
 		return null;
 	}
 
-	if (currentContext.type.id !== 'ProjectMaster' || !hasContext) {
+	if (currentContext.type.id !== 'ProjectMaster') {
 		return <Navigate to="/" />;
 	}
 


### PR DESCRIPTION
# Description

When selecting context that is not activate one will be navigated to root. 

## Definition of Done
- [x] PR title and description are to the point and understandable
- [x] I have performed a self-review of my own code
