### PR TITLE
chore: add auto merge script fro dependabot

### DIFF
--- a/.github/workflows/dependabot-auto-merge-patch.yml
+++ b/.github/workflows/dependabot-auto-merge-patch.yml
@@ -1,0 +1,26 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ github.token }}"
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# Description

To mitigate dependabot pr we can use auto merge on patches. this is done in fusion-framework

code is from fusion-framework