### PR TITLE
chore: only run changeset action on review not draft

### DIFF
--- a/.changeset/pr-401-1549632337.md
+++ b/.changeset/pr-401-1549632337.md
@@ -1,0 +1,5 @@
+
+---
+"fusion-project-portal": patch
+--- 
+Changeset action will now only run review not draft

--- a/.github/workflows/common-changeset-pr.yml
+++ b/.github/workflows/common-changeset-pr.yml
@@ -8,6 +8,7 @@ jobs:
   print_title_of_pr:
     name: Auto Generate Changset based on pull request body
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/common-changeset-pr.yml
+++ b/.github/workflows/common-changeset-pr.yml
@@ -2,7 +2,7 @@ name: Get PR description
 
 on:
   pull_request:
-    types: [opened, synchronize, edited]
+    types: [opened, synchronize, edited, ready_for_review]
 
 jobs:
   print_title_of_pr:


### PR DESCRIPTION
# Description

Update GitHub action to not run on draft mode

> Please include a summary of the change and which issue is fixed.
List any external dependencies that are required for this change.

- [x] PR title and description are to the point and understandable
- [x] I have performed a self-review of my own code'

Please select version type the purposed change:
- [ ] major
- [ ] minor
- [x] patch
- [ ] none <!--- Creates an empty changeset --> 

External Relations
- [ ] database migration


## Changeset

Changeset action will now only run review not draft
<!--- Write your changeset here -->
