### PR TITLE
fix: get changeset not running on release branch

### DIFF
--- a/.changeset/pr-406-1560342669.md
+++ b/.changeset/pr-406-1560342669.md
@@ -1,0 +1,5 @@
+
+---
+"fusion-project-portal": patch
+--- 
+The get changeset  workflow should not be triggered on the release branch

--- a/.github/workflows/common-changeset-pr.yml
+++ b/.github/workflows/common-changeset-pr.yml
@@ -8,7 +8,7 @@ jobs:
   print_title_of_pr:
     name: Auto Generate Changset based on pull request body
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.ref_name != 'changeset-release/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description

The get changeset  workflow should not be triggered on the release branch


> Please include a summary of the change and which issue is fixed.
List any external dependencies that are required for this change.

- [ ] PR title and description are to the point and understandable
- [ ] I have performed a self-review of my own code'

Please select version type the purposed change:
- [ ] major
- [ ] minor
- [x] patch
- [ ] none <!--- Creates an empty changeset --> 

External Relations
- [ ] database migration


## Changeset

The get changeset  workflow should not be triggered on the release branch
<!--- Write your changeset here -->
