### PR TITLE
fix: fusionLegacyEnvIdentifier  in capital letters

### DIFF
--- a/.changeset/pr-425-1576203123.md
+++ b/.changeset/pr-425-1576203123.md
@@ -1,0 +1,5 @@
+
+---
+"fusion-project-portal": patch
+--- 
+fusionLegacyEnvIdentifier should always be returned in capital letters , some application check this and are case sensitive

--- a/client/packages/portal-client/src/portal.config.json
+++ b/client/packages/portal-client/src/portal.config.json
@@ -40,5 +40,5 @@
 			"level": 0
 		}
 	},
-	"fusionLegacyEnvIdentifier": "ci"
+	"fusionLegacyEnvIdentifier": "CI"
 }

--- a/client/packages/portal-core/src/app/utils/app-get-legacy-client-config.ts
+++ b/client/packages/portal-core/src/app/utils/app-get-legacy-client-config.ts
@@ -6,7 +6,7 @@ export const getLegacyClientConfig = (): Client => ({
 });
 
 export const getFusionLegacyEnvIdentifier = (): string => {
-	return window._config_.fusionLegacyEnvIdentifier;
+	return window._config_.fusionLegacyEnvIdentifier.toUpperCase();
 };
 declare global {
 	interface Window {


### PR DESCRIPTION
fusionLegacyEnvIdentifier should always be returned in capital letters , some application check this and are case sensitive

# Description

> Please include a summary of the change and which issue is fixed.
List any external dependencies that are required for this change.

- [ ] PR title and description are to the point and understandable
- [ ] I have performed a self-review of my own code'

Please select version type the purposed change:
- [ ] major
- [ ] minor
- [x] patch
- [ ] none <!--- Creates an empty changeset --> 

External Relations
- [ ] database migration


## Changeset
fusionLegacyEnvIdentifier should always be returned in capital letters , some application check this and are case sensitive
<!--- Write your changeset here -->
