### PR TITLE
feat: filter service messages by notify user flag

### DIFF
--- a/.changeset/pr-470-1610845089.md
+++ b/.changeset/pr-470-1610845089.md
@@ -1,0 +1,5 @@
+
+---
+"fusion-project-portal": minor
+--- 
+The notification system has been refined to ensure users receive notifications selectively. Now, notifications will be triggered only when the "notify user" option is explicitly set on a service message item.

--- a/client/packages/service-message/components/NotificationService.tsx
+++ b/client/packages/service-message/components/NotificationService.tsx
@@ -8,12 +8,12 @@ import { css } from '@emotion/css';
 
 const messageListWrapper = css`
 	position: fixed;
-	bottom: 1rem;
-	right: 1rem;
+	bottom: 3rem;
+	right: 3rem;
 	display: flex;
 	flex-direction: column;
 	gap: 1rem;
-	width: 500px;
+	min-width: 500px;
 	z-index: 1;
 `;
 
@@ -25,13 +25,15 @@ export const NotificationService: FC<PropsWithChildren> = ({ children }) => {
 			{children}
 			<div className={messageListWrapper}>
 				{currentMessages.length > 0
-					? currentMessages.map((message) => (
-							<MessageWrapper
-								key={message.id}
-								message={message}
-								timeout={message.type === 'Maintenance' ? 8000 : 5000}
-							/>
-					  ))
+					? currentMessages
+							.filter((message) => message.notifyUser)
+							.map((message) => (
+								<MessageWrapper
+									key={message.id}
+									message={message}
+									timeout={message.type === 'Maintenance' ? 8000 : 5000}
+								/>
+							))
 					: null}
 			</div>
 		</>


### PR DESCRIPTION
# Description

Users now receive notifications only when the "notify user" option is explicitly set on a service message item. 

> Please include a summary of the change and which issue is fixed.
List any external dependencies that are required for this change.

- [ ] PR title and description are to the point and understandable
- [ ] I have performed a self-review of my own code'

Please select version type the purposed change:
- [ ] major
- [x] minor
- [ ] patch
- [ ] none <!--- Creates an empty changeset --> 

External Relations
- [ ] database migration


## Changeset

The notification system has been refined to ensure users receive notifications selectively. Now, notifications will be triggered only when the "notify user" option is explicitly set on a service message item.


<!--- Write your changeset here -->
