### PR TITLE
fix: Use default token for fusion integration

### DIFF
--- a/.changeset/pr-637-1857569361.md
+++ b/.changeset/pr-637-1857569361.md
@@ -1,0 +1,5 @@
+
+---
+"fusion-project-portal": patch
+--- 
+Change from msal to default token

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/Program.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/Program.cs
@@ -48,7 +48,11 @@ builder.Services.AddFusionIntegration(f =>
     var environment = builder.Configuration.GetValue<string>("Fusion:Environment" ?? "ci");
     f.UseServiceInformation("Fusion.Project.Portal", environment);
     f.UseDefaultEndpointResolver(environment);
-    f.UseMsalTokenProvider();
+    f.UseDefaultTokenProvider(opts =>
+    {
+        opts.ClientId = builder.Configuration.GetValue<string>("AzureAd:ClientId");
+        opts.ClientSecret = builder.Configuration.GetValue<string>("AzureAd:ClientSecret");
+    });
     f.DisableClaimsTransformation();
 });
 

--- a/clientBackend/src/Equinor.ProjectExecutionPortal.ClientBackend/Program.cs
+++ b/clientBackend/src/Equinor.ProjectExecutionPortal.ClientBackend/Program.cs
@@ -37,9 +37,14 @@ builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
 // Add fusion integration
 builder.Services.AddFusionIntegration(fusionIntegrationConfig =>
 {
-    fusionIntegrationConfig.UseServiceInformation("Fusion.Project.Portal", "Dev");
-    fusionIntegrationConfig.UseDefaultEndpointResolver("ci");
-    fusionIntegrationConfig.UseMsalTokenProvider();
+    var environment = builder.Configuration.GetValue<string>("Fusion:Environment" ?? "ci");
+    fusionIntegrationConfig.UseServiceInformation("Fusion.Project.Portal", environment);
+    fusionIntegrationConfig.UseDefaultEndpointResolver(environment);
+    fusionIntegrationConfig.UseDefaultTokenProvider(opts =>
+    {
+        opts.ClientId = builder.Configuration.GetValue<string>("AzureAd:ClientId");
+        opts.ClientSecret = builder.Configuration.GetValue<string>("AzureAd:ClientSecret");
+    });
     fusionIntegrationConfig.DisableClaimsTransformation();
 });
 

--- a/clientBackend/src/Equinor.ProjectExecutionPortal.ClientBackend/appsettings.json
+++ b/clientBackend/src/Equinor.ProjectExecutionPortal.ClientBackend/appsettings.json
@@ -16,6 +16,9 @@
     },
     "FusionLegacyEnvIdentifier": ""
   },
+  "Fusion": {
+    "Environment": "ci"
+  },
   "AzureAd": {
     "ClientId": "guid", // AppReg key
     "ClientSecret": "", // AppReg secret


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed.
List any external dependencies that are required for this change. -->
Msal token failed after a while, changing to deafult token after advice from fusion core.

- [x] PR title and description are to the point and understandable
- [x] I have performed a self-review of my own code'

Please select version type the purposed change:
- [ ] major
- [ ] minor
- [x] patch
- [ ] none <!--- Creates an empty changeset --> 

External Relations
- [ ] database migration


## Changeset

<!--- Write your changeset here -->
Change from msal to default token