### PR TITLE
fix: Highlight all text when selecting breadcrumb search field

### DIFF
--- a/.changeset/pr-687-2008126638.md
+++ b/.changeset/pr-687-2008126638.md
@@ -1,0 +1,5 @@
+
+---
+"fusion-project-portal": patch
+--- 
+Now, when selecting context  all text highlighted in the same way as we are used to in browsers.

--- a/client/packages/portal-core/src/context-selector/ContextSelector.tsx
+++ b/client/packages/portal-core/src/context-selector/ContextSelector.tsx
@@ -40,6 +40,7 @@ export const ContextSelector = ({ variant }: ContextSelectorProps) => {
 			}}
 			value={currentContext?.id ? currentContext?.title || '' : ''}
 			placeholder="Start to type to search..."
+			selectTextOnFocus={true}
 		/>
 	);
 };


### PR DESCRIPTION
# Description

Now, when selecting the search-field,  all text highlighted in the same way as we are used to in browsers.

- [x] PR title and description are to the point and understandable
- [x] I have performed a self-review of my own code'

Please select version type the purposed change:
- [ ] major
- [ ] minor
- [x] patch
- [ ] none <!--- Creates an empty changeset --> 

External Relations
- [ ] database migration


## Changeset
Now, when selecting context  all text highlighted in the same way as we are used to in browsers.
<!--- Write your changeset here -->
