### PR TITLE
fix: Project portal logging empty object for context change to Fusion features endpoint

### DIFF
--- a/.changeset/pr-689-2008366405.md
+++ b/.changeset/pr-689-2008366405.md
@@ -1,0 +1,5 @@
+
+---
+"fusion-project-portal": patch
+--- 
+The fusion feature logger will now not log when no context is selected.


### PR DESCRIPTION
# Description

 The fusion feature logger will now not log when no context is selected.

- [x] PR title and description are to the point and understandable
- [x] I have performed a self-review of my own code'

Please select version type the purposed change:
- [ ] major
- [ ] minor
- [x] patch
- [ ] none <!--- Creates an empty changeset --> 

External Relations
- [ ] database migration


## Changeset

<!--- Write your changeset here -->
 The fusion feature logger will now not log when no context is selected.
