### PR TITLE
fix: menu not closing when selecting favorite

### DIFF
--- a/.changeset/pr-691-2014284277.md
+++ b/.changeset/pr-691-2014284277.md
@@ -1,0 +1,5 @@
+
+---
+"fusion-project-portal": patch
+--- 
+Menu not closing when selecting a favorite.

--- a/client/packages/components/src/components/app-card/components/PinButton/index.tsx
+++ b/client/packages/components/src/components/app-card/components/PinButton/index.tsx
@@ -63,6 +63,7 @@ export const PinButtonContainer = ({ app, isLoading, onFavorite }: PinButtonProp
 	const pinApp = useCallback(
 		(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
 			event.preventDefault();
+			event.stopPropagation();
 			onFavorite && onFavorite(app);
 		},
 		[app, onFavorite]


### PR DESCRIPTION
# Description

The menu was closing when selecting a favorite, this is now fixed and the menu is still open.

- [x] PR title and description are to the point and understandable
- [x] I have performed a self-review of my own code'

Please select version type the purposed change:
- [ ] major
- [ ] minor
- [x] patch
- [ ] none <!--- Creates an empty changeset --> 

External Relations
- [ ] database migration


## Changeset
Menu not closing when selecting a favorite.
<!--- Write your changeset here -->
