### PR TITLE
fix:  add new route not adding double routes in pa app

### DIFF
--- a/.changeset/pr-796-2093375130.md
+++ b/.changeset/pr-796-2093375130.md
@@ -1,0 +1,5 @@
+
+---
+"fusion-project-portal": patch
+--- 
+fixing the route creation in the portal admin app

--- a/client/apps/portal-administration/src/components/PortalApps/ActionBar.tsx
+++ b/client/apps/portal-administration/src/components/PortalApps/ActionBar.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { PortalApp, PortalApplication } from '../../types';
+import { PortalApplication } from '../../types';
 import { Typography } from '@equinor/eds-core-react';
 import { useAddPortalApps, useRemovePortalApps } from '../../hooks/use-portal-apps';
 import { usePortalContext } from '../../context/PortalContext';
@@ -11,7 +11,6 @@ import { RemoveAppsButton } from '../Actions/RemoveAppsButton';
 import { EditSelectedButton } from '../Actions/EditSelectedButton';
 import { ActivateSelectedWithContextButton } from '../Actions/ActivateSelectedWithContextButton';
 import { useQueryClient } from '@tanstack/react-query';
-import { useRemoveAppWithContexts } from '../../hooks/use-add-app-with-context';
 
 const Styles = {
 	Wrapper: styled.div`

--- a/client/apps/portal-administration/src/context/RouterContext.tsx
+++ b/client/apps/portal-administration/src/context/RouterContext.tsx
@@ -88,12 +88,6 @@ export const RouterConfigContextComponent = ({ children }: PropsWithChildren) =>
 				route,
 			},
 		});
-		if (activePortalId && state.routes && state.root) {
-			updatePortalConfig({
-				id: activePortalId,
-				router: { root: state.root, routes: addRoute(route, state.routes) || [] },
-			});
-		}
 	};
 	const removeRouteById = (id: string) => {
 		dispatch({

--- a/client/apps/portal-administration/src/context/actions/router-actions.ts
+++ b/client/apps/portal-administration/src/context/actions/router-actions.ts
@@ -155,7 +155,6 @@ export const updateRouteByField = (id: string, value: string, route?: Route): Ro
 	}
 	if (id.toLowerCase().includes('message')) {
 		return {
-			description: '',
 			...route,
 			messages: { ...route.messages, [id]: value },
 		};

--- a/client/apps/portal-administration/src/context/actions/updarte-route-router-action.test.ts
+++ b/client/apps/portal-administration/src/context/actions/updarte-route-router-action.test.ts
@@ -12,7 +12,7 @@ describe('updateRoute', () => {
 		const routes: Route[] = [
 			{
 				id: '1',
-				description: undefined,
+				description: '',
 				path: '/home',
 				pageKey: 'home',
 				messages: {
@@ -22,7 +22,7 @@ describe('updateRoute', () => {
 			},
 			{
 				id: '2',
-				description: undefined,
+				description: '',
 				path: '/about',
 				pageKey: 'about',
 				messages: {
@@ -40,7 +40,7 @@ describe('updateRoute', () => {
 			{
 				children: [],
 				id: '1',
-				description: undefined,
+				description: '',
 				path: '/about',
 				pageKey: 'about',
 				messages: {
@@ -49,7 +49,7 @@ describe('updateRoute', () => {
 			},
 			{
 				id: '2',
-				description: undefined,
+				description: '',
 				path: '/about',
 				pageKey: 'about',
 				messages: {
@@ -59,7 +59,7 @@ describe('updateRoute', () => {
 					{
 						children: undefined,
 						id: '3',
-						description: undefined,
+						description: '',
 						path: '/about',
 						pageKey: 'about',
 						messages: {
@@ -72,7 +72,7 @@ describe('updateRoute', () => {
 		const newRoute = {
 			children: undefined,
 			id: '3',
-			description: undefined,
+			description: '',
 			path: '/3',
 			pageKey: '3',
 			messages: {
@@ -83,7 +83,7 @@ describe('updateRoute', () => {
 			{
 				children: [],
 				id: '1',
-				description: undefined,
+				description: '',
 				path: '/about',
 				pageKey: 'about',
 				messages: {
@@ -92,7 +92,7 @@ describe('updateRoute', () => {
 			},
 			{
 				id: '2',
-				description: undefined,
+				description: '',
 				path: '/about',
 				pageKey: 'about',
 				messages: {

--- a/client/apps/portal-administration/src/context/actions/update-route-field-router-action.test.ts
+++ b/client/apps/portal-administration/src/context/actions/update-route-field-router-action.test.ts
@@ -1,61 +1,62 @@
-import { describe, it, expect } from "vitest";
-import { updateRouteByField } from "./router-actions";
+import { describe, it, expect } from 'vitest';
+import { updateRouteByField } from './router-actions';
 
-describe("updateRouteByField", () => {
-  it("should return a new route object with the specified field updated", () => {
-    const route = {
-      id: "123",
-      messages: {
-        errorMessage: "Error",
-      },
-      path: "/home",
-      pageKey: "home",
-    };
+describe('updateRouteByField', () => {
+	it('should return a new route object with the specified field updated', () => {
+		const route = {
+			id: '123',
+			messages: {
+				errorMessage: 'Error',
+			},
+			path: '/home',
+			pageKey: 'home',
+		};
 
-    const updatedRoute = updateRouteByField("id", "456", route);
+		const updatedRoute = updateRouteByField('id', '456', route);
 
-    expect(updatedRoute).toEqual({
-      id: "456",
-      messages: {
-        errorMessage: "Error",
-      },
-      path: "/home",
-      pageKey: "home",
-    });
-  });
+		expect(updatedRoute).toEqual({
+			id: '456',
+			messages: {
+				errorMessage: 'Error',
+			},
+			path: '/home',
+			pageKey: 'home',
+		});
+	});
 
-  it("should return a new route object with the specified message field updated", () => {
-    const route = {
-      id: "123",
-      messages: {
-        errorMessage: "Error",
-      },
-      path: "/home",
-      pageKey: "home",
-    };
+	it('should return a new route object with the specified message field updated', () => {
+		const route = {
+			id: '123',
+			messages: {
+				errorMessage: 'Error',
+			},
+			path: '/home',
+			pageKey: 'home',
+		};
 
-    const updatedRoute = updateRouteByField("errorMessage", "New Error", route);
+		const updatedRoute = updateRouteByField('errorMessage', 'New Error', route);
 
-    expect(updatedRoute).toEqual({
-      id: "123",
-      messages: {
-        errorMessage: "New Error",
-      },
-      path: "/home",
-      pageKey: "home",
-    });
-  });
+		expect(updatedRoute).toEqual({
+			id: '123',
+			messages: {
+				errorMessage: 'New Error',
+			},
+			path: '/home',
+			pageKey: 'home',
+		});
+	});
 
-  it("should return a new route object with the specified field added if route is not provided", () => {
-    const updatedRoute = updateRouteByField("id", "123");
+	it('should return a new route object with the specified field added if route is not provided', () => {
+		const updatedRoute = updateRouteByField('id', '123');
 
-    expect(updatedRoute).toEqual({
-      id: "123",
-      messages: {
-        errorMessage: "",
-      },
-      path: "",
-      pageKey: "",
-    });
-  });
+		expect(updatedRoute).toEqual({
+			id: '123',
+			description: '',
+			messages: {
+				errorMessage: '',
+			},
+			path: '',
+			pageKey: '',
+		});
+	});
 });


### PR DESCRIPTION
# Description

fixing the route creation in the portal admin app

<!-- Please include a summary of the change and which issue is fixed.
List any external dependencies that are required for this change. -->

- [x] PR title and description are to the point and understandable
- [x] I have performed a self-review of my own code'

Please select version type the purposed change:
- [ ] major
- [ ] minor
- [x] patch
- [ ] none <!--- Creates an empty changeset --> 

External Relations
- [ ] database migration


## Changeset
fixing the route creation in the portal admin app
<!--- Write your changeset here -->
