### PR TITLE
change: API: rename Key to AppKey

### DIFF
--- a/.changeset/pr-844-2153430938.md
+++ b/.changeset/pr-844-2153430938.md
@@ -1,0 +1,5 @@
+
+---
+"fusion-project-portal": minor
+--- 
+Renames Key to AppKey in ApiPortallApp and ApiPortalOnboardedApp models

--- a/backend/src/Equinor.ProjectExecutionPortal.Domain/Entities/OnboardedApp.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Domain/Entities/OnboardedApp.cs
@@ -9,8 +9,8 @@ namespace Equinor.ProjectExecutionPortal.Domain.Entities;
 public class OnboardedApp : AuditableEntityBase, ICreationAuditable, IModificationAuditable
 {
     public const int AppKeyLengthMax = 200;
-    private readonly List<ContextType> _contextTypes = new();
-    private readonly List<PortalApp> _apps = new();
+    private readonly List<ContextType> _contextTypes = [];
+    private readonly List<PortalApp> _apps = [];
 
     public OnboardedApp(string appKey)
     {

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/PortalApp/ApiAddContextAppToPortalRequest.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/PortalApp/ApiAddContextAppToPortalRequest.cs
@@ -19,7 +19,7 @@ namespace Equinor.ProjectExecutionPortal.WebApi.ViewModels.PortalApp
                 RuleFor(x => x.AppKey)
                     .NotEmpty()
                     .NotContainScriptTag()
-                    .WithMessage("App Key required");
+                    .WithMessage("AppKey required");
             }
         }
     }

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/PortalApp/ApiAddGlobalAppToPortalRequest.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/PortalApp/ApiAddGlobalAppToPortalRequest.cs
@@ -27,7 +27,7 @@ namespace Equinor.ProjectExecutionPortal.WebApi.ViewModels.PortalApp
                 RuleFor(x => x.AppKey)
                     .NotEmpty()
                     .NotContainScriptTag()
-                    .WithMessage("App Key required");
+                    .WithMessage("AppKey required");
             }
         }
     }

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/PortalApp/ApiPortalApp.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/PortalApp/ApiPortalApp.cs
@@ -12,12 +12,12 @@ namespace Equinor.ProjectExecutionPortal.WebApi.ViewModels.PortalApp
         }
         public ApiPortalApp(PortalAppDto portalAppDto)
         {
-            Key = portalAppDto.OnboardedApp.AppKey;
+            AppKey = portalAppDto.OnboardedApp.AppKey;
             ContextTypes = portalAppDto.OnboardedApp.ContextTypes.Select(x => new ApiContextType(x)).ToList();
             AppManifest = portalAppDto.OnboardedApp.AppInformation != null ? new ApiFusionApp(portalAppDto.OnboardedApp.AppInformation) : null;
         }
 
-        public string Key { get; set; }
+        public string AppKey { get; set; }
         public IList<ApiContextType> ContextTypes { get; set; }
         public ApiFusionApp? AppManifest { get; set; }
     }

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/PortalApp/ApiPortalOnboardedApp.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/PortalApp/ApiPortalOnboardedApp.cs
@@ -10,7 +10,7 @@ namespace Equinor.ProjectExecutionPortal.WebApi.ViewModels.PortalApp
 
         public ApiPortalOnboardedApp(PortalOnboardedAppDto portalOnboardedAppDto)
         {
-            Key = portalOnboardedAppDto.OnboardedApp.AppKey;
+            AppKey = portalOnboardedAppDto.OnboardedApp.AppKey;
             ContextTypes = portalOnboardedAppDto.OnboardedApp.ContextTypes.Select(x => x.ContextTypeKey).ToList();
             ContextIds = portalOnboardedAppDto.ContextIds;
             IsActive = portalOnboardedAppDto.IsActive;
@@ -19,7 +19,7 @@ namespace Equinor.ProjectExecutionPortal.WebApi.ViewModels.PortalApp
             AppManifest = portalOnboardedAppDto.OnboardedApp.AppInformation != null ? new ApiFusionApp(portalOnboardedAppDto.OnboardedApp.AppInformation) : null;
         }
 
-        public string Key { get; set; }
+        public string AppKey { get; set; }
         public IList<string> ContextTypes { get; set; }
         public IList<Guid> ContextIds { get; set; }
         public bool IsActive { get; set; }

--- a/backend/src/tests/Equinor.ProjectExecutionPortal.Tests.WebApi/IntegrationTests/AssertHelpers.cs
+++ b/backend/src/tests/Equinor.ProjectExecutionPortal.Tests.WebApi/IntegrationTests/AssertHelpers.cs
@@ -47,7 +47,7 @@ namespace Equinor.ProjectExecutionPortal.Tests.WebApi.IntegrationTests
                 Assert.Fail();
             }
 
-            Assert.IsNotNull(portalAll.Key);
+            Assert.IsNotNull(portalAll.AppKey);
         }
 
         public static void AssertOnboardedAppValues(ApiOnboardedApp? onboardedApp)

--- a/backend/src/tests/Equinor.ProjectExecutionPortal.Tests.WebApi/IntegrationTests/PortalControllerTests.cs
+++ b/backend/src/tests/Equinor.ProjectExecutionPortal.Tests.WebApi/IntegrationTests/PortalControllerTests.cs
@@ -500,13 +500,13 @@ namespace Equinor.ProjectExecutionPortal.Tests.WebApi.IntegrationTests
             var appToDelete = apps.First();
 
             // Act
-            var response = await DeletePortalApp(portalToTest.Id, appToDelete.Key, UserType.Administrator);
+            var response = await DeletePortalApp(portalToTest.Id, appToDelete.AppKey, UserType.Administrator);
 
             // Assert
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
             // Verify the app is actually deleted
-            var deletedApp = await AssertGetPortalApp(portalToTest.Id, appToDelete.Key, UserType.Authenticated, HttpStatusCode.NotFound);
+            var deletedApp = await AssertGetPortalApp(portalToTest.Id, appToDelete.AppKey, UserType.Authenticated, HttpStatusCode.NotFound);
             Assert.IsNull(deletedApp);
         }
 
@@ -526,7 +526,7 @@ namespace Equinor.ProjectExecutionPortal.Tests.WebApi.IntegrationTests
             var appToDelete = apps.First();
 
             // Act
-            var response = await DeletePortalApp(portalToTest.Id, appToDelete.Key, UserType.Authenticated);
+            var response = await DeletePortalApp(portalToTest.Id, appToDelete.AppKey, UserType.Authenticated);
 
             // Assert
             Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
@@ -548,7 +548,7 @@ namespace Equinor.ProjectExecutionPortal.Tests.WebApi.IntegrationTests
             var appToDelete = apps.First();
 
             // Act
-            var response = await DeletePortalApp(portalToTest.Id, appToDelete.Key, UserType.Anonymous);
+            var response = await DeletePortalApp(portalToTest.Id, appToDelete.AppKey, UserType.Anonymous);
 
             // Assert
             Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);


### PR DESCRIPTION
# Description

Rename two API models with the following changes:

- ApiPortalApp: **Key** is now **AppKey**
- ApiPortalOnboardedApp: **Key** is now **AppKey**


- [x] PR title and description are to the point and understandable
- [x] I have performed a self-review of my own code'

Please select version type the purposed change:
- [ ] major
- [x] minor
- [ ] patch
- [ ] none <!--- Creates an empty changeset --> 

External Relations
- [ ] database migration


## Changeset

Renames Key to AppKey in ApiPortallApp and ApiPortalOnboardedApp models
