### PR TITLE
breaking: remove unused portal apps API endpoints, cleanup compiler warnings

### DIFF
--- a/.changeset/pr-853-2163110665.md
+++ b/.changeset/pr-853-2163110665.md
@@ -1,0 +1,19 @@
+
+---
+"fusion-project-portal": major
+--- 
+BREAKING CHANGE: 
+
+Updates the API endpoints that gives Portal Apps as list of objects:
+
+{portalId:guid}/apps
+{portalId:guid}/contexts/{contextId:guid}/apps
+Now instead, these endpoint returns a list of appKeys (strings).
+
+The old ones:
+
+{portalId:guid}/appkeys
+{portalId:guid}/contexts/{contextId:guid}/appkeys
+are now identical, and are deprecated and will be removed when front-end has adopted the updated endpoints.
+
+In addition some refactoring has been done. As a result, compiler warnings has been greatly reduced

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,155 +1,205 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
 root = true
-# top-most EditorConfig file
 
-# Don't use tabs for indentation.
+# All files
 [*]
 indent_style = space
 
-# ReSharper inspection severities
-resharper_arrange_constructor_or_destructor_body_highlighting = hint
-resharper_arrange_method_or_operator_body_highlighting = hint
-# (Please don't specify an indent_size here; that has too many unintended consequences.)
-
-# Code files
-[*.{cs,csx,vb,vbx}]
-indent_size = 4
-insert_final_newline = true
-charset = utf-8-bom
-
 # XML project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
-indent_size = 4
+indent_size = 2
+tab_width=2
 
 # XML config files
 [*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
 indent_size = 2
+tab_width=2
 
-# JSON files
-[*.json]
+# JSON Files
+[*.{json,json5,webmanifest}]
 indent_size = 2
+tab_width=2
 
-# Powershell files
-[*.ps1]
+# YAML Files
+[*.{yml,yaml}]
 indent_size = 2
+tab_width=2
 
-# Shell script files
+# Markdown Files
+[*.{md,mdx}]
+trim_trailing_whitespace = false
+
+# Web Files
+[*.{htm,html,js,jsm,ts,tsx,cjs,cts,ctsx,mjs,mts,mtsx,css,sass,scss,less,pcss,svg,vue}]
+indent_size = 2
+tab_width=2
+
+# Batch Files
+[*.{cmd,bat}]
+end_of_line = crlf
+
+# Bash Files
 [*.sh]
 end_of_line = lf
-indent_size = 2
 
-# Dotnet code style settings:
-[*.{cs,vb}]
-# Sort using and Import directives with System.* appearing first
-dotnet_sort_system_directives_first = true
-# Avoid "this." and "Me." if not necessary
-dotnet_style_qualification_for_field = false:refactoring
-dotnet_style_qualification_for_property = false:refactoring
-dotnet_style_qualification_for_method = false:refactoring
-dotnet_style_qualification_for_event = false:refactoring
+# Powershell
+[*.{ps1,psd1,psm1}]
+indent_size = 4
+tab_width=4
 
-# Use language keywords instead of framework type names for type references
-dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-dotnet_style_predefined_type_for_member_access = true:suggestion
+# Protobuf Files
+[*.proto]
+indent_style=tab
+indent_size=tab
+tab_width=4
 
-# Suggest more modern language features when available
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
+# Code files
+[*.{cs,csx,vb,vbx}]
+max_line_length = 200
 
-# Non-private static fields are PascalCase
-dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols = non_private_static_fields
-dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style = non_private_static_field_style
+#### Core EditorConfig Options ####
 
-dotnet_naming_symbols.non_private_static_fields.applicable_kinds = field
-dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
-dotnet_naming_symbols.non_private_static_fields.required_modifiers = static
-
-dotnet_naming_style.non_private_static_field_style.capitalization = pascal_case
-
-# Non-private readonly fields are PascalCase
-dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.symbols = non_private_readonly_fields
-dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.style = non_private_static_field_style
-
-dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds = field
-dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
-dotnet_naming_symbols.non_private_readonly_fields.required_modifiers = readonly
-
-dotnet_naming_style.non_private_readonly_field_style.capitalization = pascal_case
-
-# Constants are PascalCase
-dotnet_naming_rule.constants_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.constants_should_be_pascal_case.symbols = constants
-dotnet_naming_rule.constants_should_be_pascal_case.style = non_private_static_field_style
-
-dotnet_naming_symbols.constants.applicable_kinds = field, local
-dotnet_naming_symbols.constants.required_modifiers = const
-
-dotnet_naming_style.constant_style.capitalization = pascal_case
-
-# Instance fields are camelCase and start with _
-dotnet_naming_rule.instance_fields_should_be_camel_case.severity = suggestion
-dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
-dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
-
-dotnet_naming_symbols.instance_fields.applicable_kinds = field
-
-dotnet_naming_style.instance_field_style.capitalization = camel_case
-dotnet_naming_style.instance_field_style.required_prefix = _
-
-# Locals and parameters are camelCase
-dotnet_naming_rule.locals_should_be_camel_case.severity = suggestion
-dotnet_naming_rule.locals_should_be_camel_case.symbols = locals_and_parameters
-dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
-
-dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
-
-dotnet_naming_style.camel_case_style.capitalization = camel_case
-
-# Local functions are PascalCase
-dotnet_naming_rule.local_functions_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.local_functions_should_be_pascal_case.symbols = local_functions
-dotnet_naming_rule.local_functions_should_be_pascal_case.style = non_private_static_field_style
-
-dotnet_naming_symbols.local_functions.applicable_kinds = local_function
-
-dotnet_naming_style.local_function_style.capitalization = pascal_case
-
-# By default, name items with PascalCase
-dotnet_naming_rule.members_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
-dotnet_naming_rule.members_should_be_pascal_case.style = non_private_static_field_style
-
-dotnet_naming_symbols.all_members.applicable_kinds = *
-
-dotnet_naming_style.pascal_case_style.capitalization = pascal_case
-dotnet_style_operator_placement_when_wrapping = beginning_of_line
+# Indentation and spacing
+indent_size = 4
+indent_style = space
 tab_width = 4
-end_of_line = crlf
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_auto_properties = true:silent
-dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:silent
-dotnet_style_prefer_conditional_expression_over_return = true:silent
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_compound_assignment = true:suggestion
-dotnet_style_prefer_simplified_interpolation = true:suggestion
-dotnet_style_namespace_match_folder = true:suggestion
-dotnet_style_readonly_field = true:suggestion
 
-# CSharp code style settings:
-[*.cs]
-# Newline settings
-csharp_new_line_before_open_brace = all
-csharp_new_line_before_else = true
+# New line preferences
+end_of_line = crlf
+insert_final_newline = true
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = false
+file_header_template = unset
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Expression-level preferences
+dotnet_style_coalesce_expression = true
+dotnet_style_collection_initializer = true
+dotnet_style_explicit_tuple_names = true
+dotnet_style_namespace_match_folder = true
+dotnet_style_null_propagation = true
+dotnet_style_object_initializer = true
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_auto_properties = true
+dotnet_style_prefer_compound_assignment = true
+dotnet_style_prefer_conditional_expression_over_assignment = true
+dotnet_style_prefer_conditional_expression_over_return = true
+dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+dotnet_style_prefer_simplified_boolean_expressions = true
+dotnet_style_prefer_simplified_interpolation = true
+
+# Field preferences
+dotnet_style_readonly_field = true
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental = true
+dotnet_style_allow_statement_immediately_after_block_experimental = true
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = true
+csharp_style_var_for_built_in_types = true
+csharp_style_var_when_type_is_apparent = true
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true
+csharp_style_expression_bodied_constructors = false
+csharp_style_expression_bodied_indexers = true
+csharp_style_expression_bodied_lambdas = true
+csharp_style_expression_bodied_local_functions = false
+csharp_style_expression_bodied_methods = false
+csharp_style_expression_bodied_operators = false
+csharp_style_expression_bodied_properties = true
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true
+csharp_style_pattern_matching_over_is_with_cast_check = true
+csharp_style_prefer_extended_property_pattern = true
+csharp_style_prefer_not_pattern = true
+csharp_style_prefer_pattern_matching = true
+csharp_style_prefer_switch_expression = true
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true
+
+# Modifier preferences
+csharp_prefer_static_local_function = true
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async
+csharp_style_prefer_readonly_struct = true
+
+# Code-block preferences
+csharp_prefer_braces = true
+csharp_prefer_simple_using_statement = true
+csharp_style_namespace_declarations = file_scoped:warning
+csharp_style_prefer_method_group_conversion = true
+csharp_style_prefer_top_level_statements = true
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true
+csharp_style_deconstructed_variable_declaration = true
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+csharp_style_inlined_variable_declaration = true
+csharp_style_prefer_index_operator = true
+csharp_style_prefer_local_over_anonymous_function = true
+csharp_style_prefer_null_check_over_type_check = true
+csharp_style_prefer_range_operator = true
+csharp_style_prefer_tuple_swap = true
+csharp_style_prefer_utf8_string_literals = true
+csharp_style_throw_expression = true
+csharp_style_unused_value_assignment_preference = discard_variable
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace
+
+# New line preferences
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true
+csharp_style_allow_embedded_statements_on_same_line_experimental = true
+
+#### C# Formatting Rules ####
+
+# New line preferences
 csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
 csharp_new_line_before_finally = true
-csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
 csharp_new_line_between_query_expression_clauses = true
 
 # Indentation preferences
@@ -157,30 +207,8 @@ csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
 csharp_indent_case_contents_when_block = true
+csharp_indent_labels = one_less_than_current
 csharp_indent_switch_labels = true
-csharp_indent_labels = flush_left
-
-# Prefer "var" everywhere
-csharp_style_var_for_built_in_types = true:suggestion
-csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
-
-# Prefer method-like constructs to have a block body
-csharp_style_expression_bodied_methods = false:silent
-csharp_style_expression_bodied_constructors = false:silent
-csharp_style_expression_bodied_operators = false:none
-
-# Prefer property-like constructs to have an expression-body
-csharp_style_expression_bodied_properties = true:none
-csharp_style_expression_bodied_indexers = true:none
-csharp_style_expression_bodied_accessors = true:none
-
-# Suggest more modern language features when available
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-csharp_style_throw_expression = true:suggestion
-csharp_style_conditional_delegate_call = true:suggestion
 
 # Space preferences
 csharp_space_after_cast = false
@@ -190,7 +218,7 @@ csharp_space_after_dot = false
 csharp_space_after_keywords_in_control_flow_statements = true
 csharp_space_after_semicolon_in_for_statement = true
 csharp_space_around_binary_operators = before_and_after
-csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_around_declaration_statements = false
 csharp_space_before_colon_in_inheritance_clause = true
 csharp_space_before_comma = false
 csharp_space_before_dot = false
@@ -206,31 +234,59 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
-# Blocks are allowed
-csharp_prefer_braces = true:suggestion
+# Wrapping preferences
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = true
-csharp_using_directive_placement = outside_namespace:silent
-csharp_prefer_simple_using_statement = true:suggestion
-csharp_style_namespace_declarations = block_scoped:silent
-csharp_style_prefer_method_group_conversion = true:silent
-csharp_style_expression_bodied_lambdas = true:silent
-csharp_style_expression_bodied_local_functions = false:silent
-csharp_style_prefer_null_check_over_type_check = true:suggestion
-csharp_prefer_simple_default_expression = true:suggestion
-csharp_style_prefer_local_over_anonymous_function = true:suggestion
-csharp_style_prefer_index_operator = true:suggestion
-csharp_style_prefer_range_operator = true:suggestion
-csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
-csharp_style_prefer_tuple_swap = true:suggestion
-csharp_style_deconstructed_variable_declaration = true:suggestion
-csharp_style_unused_value_assignment_preference = discard_variable:suggestion
-csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+# Migration files
+[**/Migrations/*.cs]
+csharp_style_namespace_declarations = file_scoped:off
+dotnet_sort_system_directives_first = true
 
 [*.cs]
-# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0290
-csharp_style_prefer_primary_constructors = false
-dotnet_diagnostic.IDE0290.severity = warning
+resharper_unused_auto_property_accessor_global_highlighting=none
 
-# https://www.jetbrains.com/help/rider/ConvertToPrimaryConstructor.html
-resharper_convert_to_primary_constructor_highlighting = none 
+[*.{cs,vb}]
+dotnet_diagnostic.CA1812.severity = none

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Cache/CacheManager.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Cache/CacheManager.cs
@@ -14,9 +14,9 @@ public class CacheManager : ICacheManager
 
     public void Remove(string key) => _cache.Remove(key);
 
-    public async Task<T> GetOrCreateAsync<T>(string key, Func<Task<T>> fetch, CacheDuration duration, long expiration) where T : class
+    public async Task<T?> GetOrCreateAsync<T>(string key, Func<Task<T>> fetch, CacheDuration duration, long expiration) where T : class
     {
-        if (_cache.TryGetValue(key, out T instance))
+        if (_cache.TryGetValue(key, out T? instance))
         {
             return instance;
         }

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Cache/FusionAppsCache.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Cache/FusionAppsCache.cs
@@ -19,7 +19,7 @@ public class FusionAppsCache : IFusionAppsCache
         _cacheOptions = cacheOptions;
     }
 
-    public async Task<List<App>> GetFusionApps()
+    public async Task<List<App>?> GetFusionApps()
     {
         return await _cacheManager.GetOrCreateAsync(FusionAppCacheKey,
             async () =>

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Cache/ICacheManager.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Cache/ICacheManager.cs
@@ -6,5 +6,5 @@ public interface ICacheManager
 
     void Remove(string key);
 
-    Task<T> GetOrCreateAsync<T>(string key, Func<Task<T>> fetch, CacheDuration duration, long expiration) where T : class?;
+    Task<T?> GetOrCreateAsync<T>(string key, Func<Task<T>> fetch, CacheDuration duration, long expiration) where T : class?;
 }

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Cache/IFusionAppsCache.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Cache/IFusionAppsCache.cs
@@ -4,7 +4,7 @@ namespace Equinor.ProjectExecutionPortal.Application.Cache;
 
 public interface IFusionAppsCache
 {
-    Task<List<App>> GetFusionApps();
+    Task<List<App>?> GetFusionApps();
 
     Task<App?> GetFusionApp(string appKey);
 }

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/ContextTypes/ContextTypeDto.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/ContextTypes/ContextTypeDto.cs
@@ -4,6 +4,5 @@ namespace Equinor.ProjectExecutionPortal.Application.Queries.ContextTypes;
 
 public class ContextTypeDto : IMapFrom<Domain.Entities.ContextType>
 {
-    public string ContextTypeKey { get; set; }
-
+    public required string ContextTypeKey { get; set; }
 }

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/ContextTypes/GetContextTypes/GetContextTypesQuery.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/ContextTypes/GetContextTypes/GetContextTypesQuery.cs
@@ -8,10 +8,6 @@ namespace Equinor.ProjectExecutionPortal.Application.Queries.ContextTypes.GetCon
 
     public class GetContextTypesQuery : QueryBase<IList<ContextTypeDto>>
     {
-        public GetContextTypesQuery()
-        {
-        }
-
         public class Handler : IRequestHandler<GetContextTypesQuery, IList<ContextTypeDto>>
         {
             private readonly IReadWriteContext _context;

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/OnboardedApps/GetOnboardedApps/GetOnboardedAppsQuery.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/OnboardedApps/GetOnboardedApps/GetOnboardedAppsQuery.cs
@@ -9,10 +9,6 @@ namespace Equinor.ProjectExecutionPortal.Application.Queries.OnboardedApps.GetOn
 
 public class GetOnboardedAppsQuery : QueryBase<IList<OnboardedAppDto>>
 {
-    public GetOnboardedAppsQuery()
-    {
-    }
-
     public class Handler : IRequestHandler<GetOnboardedAppsQuery, IList<OnboardedAppDto>>
     {
         private readonly IReadWriteContext _context;

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/OnboardedApps/OnboardedAppDto.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/OnboardedApps/OnboardedAppDto.cs
@@ -7,7 +7,7 @@ namespace Equinor.ProjectExecutionPortal.Application.Queries.OnboardedApps;
 public class OnboardedAppDto : IMapFrom<Domain.Entities.OnboardedApp>
 {
     public Guid Id { get; set; }
-    public string AppKey { get; set; }
+    public required string AppKey { get; set; }
     public string? DisplayName { get; set; }
     public string? Description { get; set; }
     public App? AppInformation { get; set; }

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/OnboardedContexts/GetOnboardedContext/GetOnboardedContextByContextIdQuery.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/OnboardedContexts/GetOnboardedContext/GetOnboardedContextByContextIdQuery.cs
@@ -41,7 +41,10 @@ public class GetOnboardedContextByContextIdQuery : QueryBase<OnboardedContextDto
 
                 var onboardedContext = _mapper.Map<Domain.Entities.OnboardedContext?, OnboardedContextDto?>(entity);
 
-                await _contextService.EnrichContextWithFusionContextData(onboardedContext, cancellationToken);
+                if (onboardedContext != null)
+                {
+                    await _contextService.EnrichContextWithFusionContextData(onboardedContext, cancellationToken);
+                }
 
                 return onboardedContext;
             }
@@ -49,7 +52,6 @@ public class GetOnboardedContextByContextIdQuery : QueryBase<OnboardedContextDto
             {
                 return null;
             }
-
         }
     }
 }

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/OnboardedContexts/GetOnboardedContext/GetOnboardedContextByExternalIdContextTypeQuery.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/OnboardedContexts/GetOnboardedContext/GetOnboardedContextByExternalIdContextTypeQuery.cs
@@ -36,9 +36,13 @@ public class GetOnboardedContextByExternalIdContextTypeQuery : QueryBase<Onboard
             var entity = await _readWriteContext.Set<Domain.Entities.OnboardedContext>()
                 .AsNoTracking()
                 .FirstOrDefaultAsync(x => x.ExternalId == request.ExternalId && x.Type == request.ContextType, cancellationToken);
+
             var onboardedContext = _mapper.Map<Domain.Entities.OnboardedContext?, OnboardedContextDto?>(entity);
-            
-            await _contextService.EnrichContextWithFusionContextData(onboardedContext, cancellationToken);
+
+            if (onboardedContext != null)
+            {
+                await _contextService.EnrichContextWithFusionContextData(onboardedContext, cancellationToken);
+            }
 
             return onboardedContext;
         }

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/OnboardedContexts/OnboardedContextDto.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/OnboardedContexts/OnboardedContextDto.cs
@@ -7,10 +7,10 @@ namespace Equinor.ProjectExecutionPortal.Application.Queries.OnboardedContexts;
 public class OnboardedContextDto : IMapFrom<OnboardedContext>
 {
     public Guid Id { get; set; }
-    public string ExternalId { get; set; }
-    public string Type { get; set; }
+    public required string ExternalId { get; set; }
+    public required string Type { get; set; }
     public Guid ContextId { get; set; }
-    public string Title { get; set; }
+    public string Title { get; set; } = string.Empty;
     public string? Description { get; set; }
 
     public void SupplyWithFusionData(FusionContext context)

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/Portals/GetPortals/GetPortalsQuery.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/Portals/GetPortals/GetPortalsQuery.cs
@@ -8,10 +8,6 @@ namespace Equinor.ProjectExecutionPortal.Application.Queries.Portals.GetPortals;
 
 public class GetPortalsQuery : QueryBase<IList<PortalDto>>
 {
-    public GetPortalsQuery()
-    {
-    }
-
     public class Handler : IRequestHandler<GetPortalsQuery, IList<PortalDto>>
     {
         private readonly IReadWriteContext _context;
@@ -31,11 +27,6 @@ public class GetPortalsQuery : QueryBase<IList<PortalDto>>
                 .ToListAsync(cancellationToken);
 
             var portals = _mapper.Map<List<Domain.Entities.Portal>, List<PortalDto>>(entities);
-
-            // This causes projection to lazy load
-            //var entities = await _context.Set<Domain.Entities.portal>()
-            //    .AsNoTracking()
-            //    .ProjectToListAsync<PortalDto>(_mapper.ConfigurationProvider);
 
             return portals;
         }

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/Portals/PortalAppDto.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/Portals/PortalAppDto.cs
@@ -1,11 +1,9 @@
 ﻿using Equinor.ProjectExecutionPortal.Application.Infrastructure.Mappings;
 using Equinor.ProjectExecutionPortal.Application.Queries.OnboardedApps;
 
-namespace Equinor.ProjectExecutionPortal.Application.Queries.Portals
+namespace Equinor.ProjectExecutionPortal.Application.Queries.Portals;
+
+public class PortalAppDto : IMapFrom<Domain.Entities.PortalApp>
 {
-    public class PortalAppDto : IMapFrom<Domain.Entities.PortalApp>
-    {
-        public bool IsHidden { get; set; }
-        public OnboardedAppDto OnboardedApp { get; set; }
-    }
+    public required OnboardedAppDto OnboardedApp { get; set; }
 }

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/Portals/PortalDto.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/Portals/PortalDto.cs
@@ -1,19 +1,18 @@
 ﻿using Equinor.ProjectExecutionPortal.Application.Infrastructure.Mappings;
 using Equinor.ProjectExecutionPortal.Application.Queries.ContextTypes;
 
-namespace Equinor.ProjectExecutionPortal.Application.Queries.Portals
+namespace Equinor.ProjectExecutionPortal.Application.Queries.Portals;
+
+public class PortalDto : IMapFrom<Domain.Entities.Portal>
 {
-    public class PortalDto : IMapFrom<Domain.Entities.Portal>
-    {
-        public Guid Id { get; set; }
-        public required string Key { get; set; }
-        public required string Name { get; set; }
-        public required string ShortName { get; set; }
-        public required string SubText { get; set; }
-        public string? Description { get; set; }
-        public required string Icon { get; set; }
-        public required IList<ContextTypeDto> ContextTypes { get; set; }
-        public required List<PortalAppDto> Apps { get; set; }
-        public PortalConfigurationDto? Configuration { get; set; }
-    }
+    public Guid Id { get; set; }
+    public required string Key { get; set; }
+    public required string Name { get; set; }
+    public required string ShortName { get; set; }
+    public required string SubText { get; set; }
+    public string? Description { get; set; }
+    public required string Icon { get; set; }
+    public required IList<ContextTypeDto> ContextTypes { get; set; }
+    public required List<PortalAppDto> Apps { get; set; }
+    public PortalConfigurationDto? Configuration { get; set; }
 }

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/Portals/PortalOnboardedAppDto.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/Portals/PortalOnboardedAppDto.cs
@@ -5,9 +5,9 @@ namespace Equinor.ProjectExecutionPortal.Application.Queries.Portals;
 
 public class PortalOnboardedAppDto : IMapFrom<Domain.Entities.PortalApp>
 {
-    public OnboardedAppDto OnboardedApp { get; set; }
+    public required OnboardedAppDto OnboardedApp { get; set; }
     public List<Guid> ContextIds { get; set; } = [];
-    public bool IsActive { get; set; } = false;
+    public bool IsActive { get; set; }
     public bool IsGlobal { get; set; }
     public bool IsContextual { get; set; }
 }

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Services/AppService/AppService.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Services/AppService/AppService.cs
@@ -37,9 +37,9 @@ public class AppService : IAppService
         return onboardedApps;
     }
 
-    private static void CombineAppWithFusionAppData(OnboardedAppDto onboardedApp, IEnumerable<App> fusionApps)
+    private static void CombineAppWithFusionAppData(OnboardedAppDto onboardedApp, IEnumerable<App>? fusionApps)
     {
-        var fusionApp = fusionApps.FirstOrDefault(fusionApp => string.Equals(fusionApp.AppKey, onboardedApp.AppKey, StringComparison.CurrentCultureIgnoreCase));
+        var fusionApp = fusionApps?.FirstOrDefault(fusionApp => string.Equals(fusionApp.AppKey, onboardedApp.AppKey, StringComparison.CurrentCultureIgnoreCase));
 
         if (fusionApp != null)
         {

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Services/ContextTypeService/ContextTypeService.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Services/ContextTypeService/ContextTypeService.cs
@@ -1,5 +1,4 @@
-﻿using Equinor.ProjectExecutionPortal.Domain.Common.Exceptions;
-using Equinor.ProjectExecutionPortal.Domain.Entities;
+﻿using Equinor.ProjectExecutionPortal.Domain.Entities;
 using Equinor.ProjectExecutionPortal.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Services/FusionAppsService/FusionAppsService.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Services/FusionAppsService/FusionAppsService.cs
@@ -2,39 +2,38 @@
 using Fusion.Integration.Apps.Abstractions.Abstractions;
 using Fusion.Integration.Apps.Abstractions.Models;
 
-namespace Equinor.ProjectExecutionPortal.Application.Services.FusionAppsService
+namespace Equinor.ProjectExecutionPortal.Application.Services.FusionAppsService;
+
+public class FusionAppsService : IFusionAppsService
 {
-    public class FusionAppsService : IFusionAppsService
+    private readonly IFusionAppsCache _fusionAppsCache;
+    private readonly IAppsClient _fusionAppsClient;
+
+    public FusionAppsService(IFusionAppsCache fusionAppsCache, IAppsClient fusionAppsClient)
     {
-        private readonly IFusionAppsCache _fusionAppsCache;
-        private readonly IAppsClient _fusionAppsClient;
+        _fusionAppsCache = fusionAppsCache;
+        _fusionAppsClient = fusionAppsClient;
+    }
 
-        public FusionAppsService(IFusionAppsCache fusionAppsCache, IAppsClient fusionAppsClient)
-        {
-            _fusionAppsCache = fusionAppsCache;
-            _fusionAppsClient = fusionAppsClient;
-        }
+    public async Task<bool> FusionAppExist(string appKey, CancellationToken cancellationToken)
+    {
+        var fusionApps = await _fusionAppsCache.GetFusionApps();
 
-        public async Task<bool> FusionAppExist(string appKey, CancellationToken cancellationToken)
-        {
-            var fusionApps = await _fusionAppsCache.GetFusionApps();
+        return fusionApps != null && fusionApps.Any(app => app.AppKey == appKey);
+    }
 
-            return fusionApps.Any(app => app.AppKey == appKey);
-        }
+    public async Task<IList<App>?> GetFusionApps()
+    {
+        return await _fusionAppsCache.GetFusionApps();
+    }
 
-        public async Task<IList<App>> GetFusionApps()
-        {
-            return await _fusionAppsCache.GetFusionApps();
-        }
+    public async Task<App?> GetFusionApp(string appKey)
+    {
+        return await _fusionAppsCache.GetFusionApp(appKey);
+    }
 
-        public async Task<App?> GetFusionApp(string appKey)
-        {
-            return await _fusionAppsCache.GetFusionApp(appKey);
-        }
-
-        public async Task<AppConfiguration?> GetFusionAppConfig(string appKey)
-        {
-            return await _fusionAppsClient.GetAppConfig(appKey, new TagNameIdentifier("latest"));
-        }
+    public async Task<AppConfiguration?> GetFusionAppConfig(string appKey)
+    {
+        return await _fusionAppsClient.GetAppConfig(appKey, new TagNameIdentifier("latest"));
     }
 }

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Services/FusionAppsService/IFusionAppsService.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Services/FusionAppsService/IFusionAppsService.cs
@@ -1,15 +1,14 @@
 ﻿using Fusion.Integration.Apps.Abstractions.Models;
 
-namespace Equinor.ProjectExecutionPortal.Application.Services.FusionAppsService
+namespace Equinor.ProjectExecutionPortal.Application.Services.FusionAppsService;
+
+public interface IFusionAppsService
 {
-    public interface IFusionAppsService
-    {
-        Task<bool> FusionAppExist(string appKey, CancellationToken cancellationToken);
+    Task<bool> FusionAppExist(string appKey, CancellationToken cancellationToken);
 
-        Task<IList<App>> GetFusionApps();
+    Task<IList<App>?> GetFusionApps();
 
-        Task<App?> GetFusionApp(string appKey);
+    Task<App?> GetFusionApp(string appKey);
 
-        Task<AppConfiguration?> GetFusionAppConfig(string appKey);
-    }
+    Task<AppConfiguration?> GetFusionAppConfig(string appKey);
 }

--- a/backend/src/Equinor.ProjectExecutionPortal.Domain/Entities/ContextType.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Domain/Entities/ContextType.cs
@@ -1,23 +1,22 @@
 ﻿using Equinor.ProjectExecutionPortal.Domain.Common;
 using Equinor.ProjectExecutionPortal.Domain.Common.Audit;
 
-namespace Equinor.ProjectExecutionPortal.Domain.Entities
+namespace Equinor.ProjectExecutionPortal.Domain.Entities;
+
+public class ContextType : AuditableEntityBase, ICreationAuditable, IModificationAuditable
 {
-    public class ContextType : AuditableEntityBase, ICreationAuditable, IModificationAuditable
+    public const int ContextTypeKeyLengthMax = 200;
+
+    private readonly List<Portal> _portals = [];
+    private readonly List<OnboardedApp> _onboardedApps = [];
+
+    public ContextType(string contextTypeKey)
     {
-        public const int ContextTypeKeyLengthMax = 200;
-
-        private readonly List<Portal> _portals = [];
-        private readonly List<OnboardedApp> _onboardedApps = [];
-
-        public ContextType(string contextTypeKey)
-        {
-            ContextTypeKey = contextTypeKey;
-        }
-
-        public string ContextTypeKey { get; set; }
-
-        public IReadOnlyCollection<Portal> Portals => _portals.AsReadOnly();
-        public IReadOnlyCollection<OnboardedApp> OnboardedApps => _onboardedApps.AsReadOnly();
+        ContextTypeKey = contextTypeKey;
     }
+
+    public string ContextTypeKey { get; set; }
+
+    public IReadOnlyCollection<Portal> Portals => _portals.AsReadOnly();
+    public IReadOnlyCollection<OnboardedApp> OnboardedApps => _onboardedApps.AsReadOnly();
 }

--- a/backend/src/Equinor.ProjectExecutionPortal.Domain/Entities/PortalApp.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Domain/Entities/PortalApp.cs
@@ -26,10 +26,10 @@ public class PortalApp : AuditableEntityBase, ICreationAuditable, IModificationA
     public bool IsHidden { get; set; }
 
     public Guid OnboardedAppId { get; set; }
-    public OnboardedApp OnboardedApp { get; set; }
-    
+    public OnboardedApp OnboardedApp { get; set; } = null!;
+
     public Guid PortalId { get; set; }
-    public Portal Portal { get; set; }
+    public Portal Portal { get; set; } = null!;
 
     public Guid? OnboardedContextId { get; set; }
     public OnboardedContext? OnboardedContext { get; set; }

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/Controllers/ApiControllerBase.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/Controllers/ApiControllerBase.cs
@@ -20,29 +20,4 @@ public abstract class ApiControllerBase : Controller
     protected ILogger Logger => _logger;
     protected IAuthorizationService AuthorizationService => _authorizationService ??= HttpContext.RequestServices.GetRequiredService<IAuthorizationService>();
     protected IFusionContextResolver ContextResolver => _contextResolver ??= HttpContext.RequestServices.GetRequiredService<IFusionContextResolver>();
-
-    private protected async Task<Unit> SetAuthorizedVerbsHeader(List<(string verb, string policy)> verbPolicyMap, object? resource)
-    {
-        var allowedVerbs = await GetAuthorizedVerbs(verbPolicyMap, resource);
-        HttpContext.Response.Headers.Add("Allow", string.Join(',', allowedVerbs));
-
-        return Unit.Value;
-    }
-
-    private async Task<List<string>> GetAuthorizedVerbs(List<(string verb, string policy)> verbPolicyMap, object? resource)
-    {
-        var allowedVerbs = new List<string> { HttpMethod.Options.Method }; // Always allowed
-
-        foreach (var (verb, policy) in verbPolicyMap)
-        {
-            var authResult = await AuthorizationService.AuthorizeAsync(User, resource, policy);
-
-            if (authResult.Succeeded)
-            {
-                allowedVerbs.Add(verb);
-            }
-        }
-
-        return allowedVerbs;
-    }
 }

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/Controllers/ContextTypeController.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/Controllers/ContextTypeController.cs
@@ -7,85 +7,84 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Equinor.ProjectExecutionPortal.WebApi.Controllers
+namespace Equinor.ProjectExecutionPortal.WebApi.Controllers;
+
+[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+[ApiVersion("0.1")]
+[Route("api/context-types")]
+public class ContextTypeController : ApiControllerBase
 {
-    [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
-    [ApiVersion("0.1")]
-    [Route("api/context-types")]
-    public class ContextTypeController : ApiControllerBase
+    // GET: api/<ContextTypeController>
+    [HttpGet("")]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<IList<ApiContextType>>> ContextTypes()
     {
-        // GET: api/<ContextTypeController>
-        [HttpGet("")]
-        [Produces(MediaTypeNames.Application.Json)]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
-        public async Task<ActionResult<IList<ApiContextType>>> ContextTypes()
-        {
-            var contextTypesDto = await Mediator.Send(new GetContextTypesQuery());
+        var contextTypesDto = await Mediator.Send(new GetContextTypesQuery());
 
-            return Ok(contextTypesDto.Select(contextTypeDto => new ApiContextType(contextTypeDto)).ToList());
+        return Ok(contextTypesDto.Select(contextTypeDto => new ApiContextType(contextTypeDto)).ToList());
+    }
+
+    // POST api/<ContextTypeController>
+    [HttpPost("")]
+    [Authorize(Policy = Policies.ProjectPortal.Admin)]
+    [Consumes(MediaTypeNames.Application.Json)]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<Guid>> AddContextType([FromBody] ApiAddContextTypeRequest request)
+    {
+        try
+        {
+            await Mediator.Send(request.ToCommand());
+        }
+        catch (NotFoundException ex)
+        {
+            return FusionApiError.NotFound(request.Type, ex.Message);
+        }
+        catch (InvalidActionException ex)
+        {
+            return FusionApiError.ResourceExists(request.Type, "Context type is already supported", ex);
+        }
+        catch (Exception)
+        {
+            return FusionApiError.InvalidOperation("500", "An error occurred while adding context type");
         }
 
-        // POST api/<ContextTypeController>
-        [HttpPost("")]
-        [Authorize(Policy = Policies.ProjectPortal.Admin)]
-        [Consumes(MediaTypeNames.Application.Json)]
-        [Produces(MediaTypeNames.Application.Json)]
-        [ProducesResponseType(StatusCodes.Status201Created)]
-        [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
-        [ProducesResponseType(typeof(void), StatusCodes.Status409Conflict)]
-        public async Task<ActionResult<Guid>> AddContextType([FromBody] ApiAddContextTypeRequest request)
-        {
-            try
-            {
-                await Mediator.Send(request.ToCommand());
-            }
-            catch (NotFoundException ex)
-            {
-                return FusionApiError.NotFound(request.Type, ex.Message);
-            }
-            catch (InvalidActionException ex)
-            {
-                return FusionApiError.ResourceExists(request.Type, "Context type is already supported", ex);
-            }
-            catch (Exception)
-            {
-                return FusionApiError.InvalidOperation("500", "An error occurred while adding context type");
-            }
+        return Created("Created", request);
+    }
 
-            return Created("Created", request);
+    // DELETE api/<ContextTypeController>/5
+    [HttpDelete("{contextType}")]
+    [Authorize(Policy = Policies.ProjectPortal.Admin)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> RemoveContextType([FromRoute] string contextType)
+    {
+        var request = new ApiRemoveContextTypeRequest { Type = contextType };
+
+        try
+        {
+            await Mediator.Send(request.ToCommand());
+        }
+        catch (NotFoundException ex)
+        {
+            return FusionApiError.NotFound(contextType, ex.Message);
+        }
+        catch (InvalidActionException ex)
+        {
+            return FusionApiError.InvalidOperation("404", ex.Message);
+        }
+        catch (Exception)
+        {
+            return FusionApiError.InvalidOperation("500", "An error occurred while removing context type");
         }
 
-        // DELETE api/<ContextTypeController>/5
-        [HttpDelete("{contextType}")]
-        [Authorize(Policy = Policies.ProjectPortal.Admin)]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
-        [ProducesResponseType(typeof(void), StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult> RemoveContextType([FromRoute] string contextType)
-        {
-            var request = new ApiRemoveContextTypeRequest { Type = contextType };
-
-            try
-            {
-                await Mediator.Send(request.ToCommand());
-            }
-            catch (NotFoundException ex)
-            {
-                return FusionApiError.NotFound(contextType, ex.Message);
-            }
-            catch (InvalidActionException ex)
-            {
-                return FusionApiError.InvalidOperation("404", ex.Message);
-            }
-            catch (Exception)
-            {
-                return FusionApiError.InvalidOperation("500", "An error occurred while removing context type");
-            }
-
-            return Ok();
-        }
+        return Ok();
     }
 }

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/Controllers/PortalController.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/Controllers/PortalController.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net.Mime;
 using Equinor.ProjectExecutionPortal.Application.Queries.Portals.GetPortal;
 using Equinor.ProjectExecutionPortal.Application.Queries.Portals.GetPortalAppKeys;
-using Equinor.ProjectExecutionPortal.Application.Queries.Portals.GetPortalApps;
 using Equinor.ProjectExecutionPortal.Application.Queries.Portals.GetPortalConfiguration;
 using Equinor.ProjectExecutionPortal.Application.Queries.Portals.GetPortalOnboardedApp;
 using Equinor.ProjectExecutionPortal.Application.Queries.Portals.GetPortalOnboardedApps;
@@ -204,10 +203,10 @@ public class PortalController : ApiControllerBase
         return new ApiPortalOnboardedApp(portalOnboardedAppDto);
     }
 
-    // App Keys
+    // Apps
 
-    // TODO: Rename to /apps
-    [HttpGet("{portalId:guid}/appkeys")]
+    [HttpGet("{portalId:guid}/apps")]
+    [HttpGet("{portalId:guid}/appkeys")] // TODO: DEPRECATED
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<List<string>>> PortalAppKeys([FromRoute] Guid portalId)
@@ -228,8 +227,8 @@ public class PortalController : ApiControllerBase
         }
     }
 
-    // TODO Rename to /apps
-    [HttpGet("{portalId:guid}/contexts/{contextId:guid}/appkeys")]
+    [HttpGet("{portalId:guid}/contexts/{contextId:guid}/apps")]
+    [HttpGet("{portalId:guid}/contexts/{contextId:guid}/appkeys")] // TODO: DEPRECATED
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<List<string>>> PortalAppKeys([FromRoute] Guid portalId, [FromRoute] Guid contextId)
@@ -239,52 +238,6 @@ public class PortalController : ApiControllerBase
             var portalContextualAppKeys = await Mediator.Send(new GetContextualAndGlobalAppKeysByPortalAndContextQuery(portalId, contextId));
 
             return Ok(portalContextualAppKeys);
-        }
-        catch (NotFoundException ex)
-        {
-            return FusionApiError.NotFound(portalId, ex.Message);
-        }
-        catch (Exception)
-        {
-            return FusionApiError.InvalidOperation("500", "An error occurred");
-        }
-    }
-
-    // Apps
-
-    // TODO: Remove
-    [HttpGet("{portalId:guid}/apps")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<List<ApiPortalApp>>> PortalApps([FromRoute] Guid portalId)
-    {
-        try
-        {
-            var portalAppsDto = await Mediator.Send(new GetGlobalAppsForPortalQuery(portalId));
-
-            return Ok(portalAppsDto.Select(portalAppDto => new ApiPortalApp(portalAppDto)).ToList());
-        }
-        catch (NotFoundException ex)
-        {
-            return FusionApiError.NotFound(portalId, ex.Message);
-        }
-        catch (Exception)
-        {
-            return FusionApiError.InvalidOperation("500", "An error occurred");
-        }
-    }
-
-    // TODO: Remove
-    [HttpGet("{portalId:guid}/contexts/{contextId:guid}/apps")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<List<ApiPortalApp>>> PortalApps([FromRoute] Guid portalId, [FromRoute] Guid contextId)
-    {
-        try
-        {
-            var portalAppsDto = await Mediator.Send(new GetContextualAndGlobalAppsByPortalAndContextQuery(portalId, contextId));
-
-            return Ok(portalAppsDto.Select(portalAppDto => new ApiPortalApp(portalAppDto)).ToList());
         }
         catch (NotFoundException ex)
         {

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/ContextType/ApiContextType.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/ContextType/ApiContextType.cs
@@ -4,8 +4,11 @@ namespace Equinor.ProjectExecutionPortal.WebApi.ViewModels.ContextType;
 
 public class ApiContextType
 {
+#pragma warning disable CS8618 // For integration tests only
     public ApiContextType()
-    { }
+#pragma warning restore CS8618 // For integration tests only
+    {
+    }
 
     public ApiContextType(ContextTypeDto contextTypeDto)
     {

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/FusionApp/ApiFusionApp.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/FusionApp/ApiFusionApp.cs
@@ -4,7 +4,9 @@ namespace Equinor.ProjectExecutionPortal.WebApi.ViewModels.FusionApp;
 
 public class ApiFusionApp
 {
+#pragma warning disable CS8618 // For integration tests only
     public ApiFusionApp()
+#pragma warning restore CS8618 // For integration tests only
     {
     }
 

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/FusionApp/ApiFusionAppCategory.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/FusionApp/ApiFusionAppCategory.cs
@@ -4,8 +4,11 @@ namespace Equinor.ProjectExecutionPortal.WebApi.ViewModels.FusionApp;
 
 public class ApiFusionAppCategory
 {
+#pragma warning disable CS8618 // // For integration tests only
     public ApiFusionAppCategory()
-    { }
+#pragma warning restore CS8618 // // For integration tests only
+    {
+    }
 
     public ApiFusionAppCategory(AppCategory fusionAppCategory)
     {

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/FusionApp/ApiFusionAppVersion.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/FusionApp/ApiFusionAppVersion.cs
@@ -4,8 +4,11 @@ namespace Equinor.ProjectExecutionPortal.WebApi.ViewModels.FusionApp;
 
 public class ApiFusionAppVersion
 {
+#pragma warning disable CS8618 // For integration tests only
     public ApiFusionAppVersion()
-    { }
+#pragma warning restore CS8618 // For integration tests only
+    {
+    }
 
     public ApiFusionAppVersion(AppVersion fusionAppVersion)
     {

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/OnboardedApp/ApiOnboardAppRequest.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/OnboardedApp/ApiOnboardAppRequest.cs
@@ -21,6 +21,10 @@ public class ApiOnboardAppRequest
                 .NotEmpty()
                 .NotContainScriptTag()
                 .WithMessage("AppKey is required");
+
+            RuleFor(x => x.ContextTypes)
+                .NotEmpty()
+                .WithMessage("Context Types is required");
         }
     }
 }

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/OnboardedApp/ApiOnboardedApp.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/OnboardedApp/ApiOnboardedApp.cs
@@ -5,8 +5,11 @@ namespace Equinor.ProjectExecutionPortal.WebApi.ViewModels.OnboardedApp;
 
 public class ApiOnboardedApp
 {
+#pragma warning disable CS8618 // For integration tests only
     public ApiOnboardedApp()
-    { }
+#pragma warning restore CS8618 // For integration tests only
+    {
+    }
 
     public ApiOnboardedApp(OnboardedAppDto onboardedAppDto)
     {

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/OnboardedApp/ApiUpdateOnboardedAppRequest.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/OnboardedApp/ApiUpdateOnboardedAppRequest.cs
@@ -16,7 +16,9 @@ public class ApiUpdateOnboardedAppRequest
     {
         public ApiUpdateOnboardedAppRequestValidator()
         {
-               
+            RuleFor(x => x.ContextTypes)
+                .NotNull()
+                .WithMessage("Context Types is required");
         }
     }
 }

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/OnboardedContext/ApiOnboardedContext.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/OnboardedContext/ApiOnboardedContext.cs
@@ -4,7 +4,9 @@ namespace Equinor.ProjectExecutionPortal.WebApi.ViewModels.OnboardedContext;
 
 public class ApiOnboardedContext
 {
+#pragma warning disable CS8618 // For integration tests only
     public ApiOnboardedContext() { }
+#pragma warning restore CS8618 // For integration tests only
 
     public ApiOnboardedContext(OnboardedContextDto onboardedAppDto)
     {

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/Portal/ApiPortal.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/Portal/ApiPortal.cs
@@ -6,7 +6,9 @@ namespace Equinor.ProjectExecutionPortal.WebApi.ViewModels.Portal;
 
 public class ApiPortal
 {
+#pragma warning disable CS8618 // For integration tests only
     public ApiPortal() { }
+#pragma warning restore CS8618 // For integration tests only
 
     public ApiPortal(PortalDto portalDto)
     {

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/PortalApp/ApiPortalApp.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/PortalApp/ApiPortalApp.cs
@@ -7,10 +7,12 @@ namespace Equinor.ProjectExecutionPortal.WebApi.ViewModels.PortalApp;
 // TODO: Should be removed
 public class ApiPortalApp
 {
+#pragma warning disable CS8618 // For integration tests only
     public ApiPortalApp()
+#pragma warning restore CS8618 // For integration tests only
     {
-
     }
+
     public ApiPortalApp(PortalAppDto portalAppDto)
     {
         AppKey = portalAppDto.OnboardedApp.AppKey;

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/PortalApp/ApiPortalApp.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/PortalApp/ApiPortalApp.cs
@@ -4,7 +4,6 @@ using Equinor.ProjectExecutionPortal.WebApi.ViewModels.FusionApp;
 
 namespace Equinor.ProjectExecutionPortal.WebApi.ViewModels.PortalApp;
 
-// TODO: Should be removed
 public class ApiPortalApp
 {
 #pragma warning disable CS8618 // For integration tests only

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/PortalApp/ApiPortalOnboardedApp.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/PortalApp/ApiPortalOnboardedApp.cs
@@ -5,8 +5,11 @@ namespace Equinor.ProjectExecutionPortal.WebApi.ViewModels.PortalApp;
 
 public class ApiPortalOnboardedApp
 {
+#pragma warning disable CS8618 // For integration tests only
     public ApiPortalOnboardedApp()
-    { }
+#pragma warning restore CS8618 // For integration tests only
+    {
+    }
 
     public ApiPortalOnboardedApp(PortalOnboardedAppDto portalOnboardedAppDto)
     {

--- a/backend/src/tests/Equinor.ProjectExecutionPortal.Tests.WebApi/IntegrationTests/ContextTypeControllerTests.cs
+++ b/backend/src/tests/Equinor.ProjectExecutionPortal.Tests.WebApi/IntegrationTests/ContextTypeControllerTests.cs
@@ -230,7 +230,7 @@ public class ContextTypeControllerTests : TestBase
 
         if (response.StatusCode != HttpStatusCode.OK)
         {
-            return contextTypes;
+            return contextTypes!;
         }
 
         Assert.IsNotNull(content);

--- a/backend/src/tests/Equinor.ProjectExecutionPortal.Tests.WebApi/IntegrationTests/PortalControllerTests.cs
+++ b/backend/src/tests/Equinor.ProjectExecutionPortal.Tests.WebApi/IntegrationTests/PortalControllerTests.cs
@@ -532,13 +532,13 @@ public class PortalControllerTests : TestBase
         var appToDelete = apps.First();
 
         // Act
-        var response = await DeletePortalApp(portalToTest.Id, appToDelete.AppKey, UserType.Administrator);
+        var response = await DeletePortalApp(portalToTest.Id, appToDelete, UserType.Administrator);
 
         // Assert
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 
         // Verify the app is actually deleted
-        var deletedApp = await AssertGetPortalApp(portalToTest.Id, appToDelete.AppKey, UserType.Authenticated, HttpStatusCode.NotFound);
+        var deletedApp = await AssertGetPortalApp(portalToTest.Id, appToDelete, UserType.Authenticated, HttpStatusCode.NotFound);
         Assert.IsNull(deletedApp);
     }
 
@@ -558,7 +558,7 @@ public class PortalControllerTests : TestBase
         var appToDelete = apps.First();
 
         // Act
-        var response = await DeletePortalApp(portalToTest.Id, appToDelete.AppKey, UserType.Authenticated);
+        var response = await DeletePortalApp(portalToTest.Id, appToDelete, UserType.Authenticated);
 
         // Assert
         Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
@@ -580,7 +580,7 @@ public class PortalControllerTests : TestBase
         var appToDelete = apps.First();
 
         // Act
-        var response = await DeletePortalApp(portalToTest.Id, appToDelete.AppKey, UserType.Anonymous);
+        var response = await DeletePortalApp(portalToTest.Id, appToDelete, UserType.Anonymous);
 
         // Assert
         Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -708,30 +708,30 @@ public class PortalControllerTests : TestBase
         return appKeys;
     }
 
-    private static async Task<IList<ApiPortalApp>?> AssertGetAppsForPortal(Guid portalId, Guid? contextId, UserType userType, HttpStatusCode expectedStatusCode)
+    private static async Task<IList<string>?> AssertGetAppsForPortal(Guid portalId, Guid? contextId, UserType userType, HttpStatusCode expectedStatusCode)
     {
         // Act
         var response = await GetAppsForPortal(portalId, contextId, userType);
         var content = await response.Content.ReadAsStringAsync();
-        var apps = JsonConvert.DeserializeObject<IList<ApiPortalApp>>(content);
+        var appKeys = JsonConvert.DeserializeObject<IList<string>>(content);
 
         // Assert
         Assert.AreEqual(expectedStatusCode, response.StatusCode);
 
         if (response.StatusCode != HttpStatusCode.OK)
         {
-            return apps;
+            return appKeys;
         }
 
         Assert.IsNotNull(content);
-        Assert.IsNotNull(apps);
+        Assert.IsNotNull(appKeys);
 
-        foreach (var app in apps)
+        foreach (var appKey in appKeys)
         {
-            AssertHelpers.AssertPortalAppValues(app);
+            Assert.IsNotNull(appKey);
         }
 
-        return apps;
+        return appKeys;
     }
 
     private static async Task<HttpResponseMessage> CreatePortal(UserType userType, ApiCreatePortalRequest createdPortal)

--- a/backend/src/tests/Equinor.ProjectExecutionPortal.Tests.WebApi/Setup/IntegrationTestAuthHandler.cs
+++ b/backend/src/tests/Equinor.ProjectExecutionPortal.Tests.WebApi/Setup/IntegrationTestAuthHandler.cs
@@ -11,7 +11,7 @@ namespace Equinor.ProjectExecutionPortal.Tests.WebApi.Setup;
 
 internal class IntegrationTestAuthHandler : AuthenticationHandler<IntegrationTestAuthOptions>
 {
-    public static string TestAuthenticationScheme = "AuthScheme";
+    public const string TestAuthenticationScheme = "AuthScheme";
 
     private enum AuthType
     {
@@ -19,12 +19,7 @@ internal class IntegrationTestAuthHandler : AuthenticationHandler<IntegrationTes
         Delegated
     }
 
-    public IntegrationTestAuthHandler(
-        IOptionsMonitor<IntegrationTestAuthOptions> options,
-        ILoggerFactory logger,
-        UrlEncoder encoder,
-        ISystemClock clock)
-        : base(options, logger, encoder, clock)
+    public IntegrationTestAuthHandler(IOptionsMonitor<IntegrationTestAuthOptions> options, ILoggerFactory logger, UrlEncoder encoder) : base(options, logger, encoder)
     {
     }
 
@@ -83,6 +78,7 @@ internal class IntegrationTestAuthHandler : AuthenticationHandler<IntegrationTes
                 {
                     claims.AddRange(profile.AppRoles.Select(role => new Claim(ClaimTypes.Role, role)));
                 }
+
                 break;
 
             case AuthType.Application:
@@ -90,6 +86,7 @@ internal class IntegrationTestAuthHandler : AuthenticationHandler<IntegrationTes
                 {
                     claims.AddRange(profile.AppRoles.Select(role => new Claim(ClaimTypes.Role, role)));
                 }
+
                 break;
         }
 

--- a/backend/src/tests/Equinor.ProjectExecutionPortal.Tests.WebApi/TestFactory.cs
+++ b/backend/src/tests/Equinor.ProjectExecutionPortal.Tests.WebApi/TestFactory.cs
@@ -23,13 +23,13 @@ public sealed class TestFactory : WebApplicationFactory<Program>
     private const string IntegrationTestEnvironment = "IntegrationTests";
     private readonly string _localDbConnectionString;
     private readonly string _configPath;
-    private readonly List<Action> _teardownList = new();
-    private readonly List<IDisposable> _disposables = new();
+    private readonly List<Action> _teardownList = [];
+    private readonly List<IDisposable> _disposables = [];
     private readonly Mock<IFusionContextResolver> _fusionContextResolverMock = new();
     private readonly Mock<IAppsClient> _fusionAppsClientMock = new();
     public static Dictionary<UserType, ITestUser> TestUsersDictionary = new();
     private static TestFactory? _sInstance;
-    private static readonly object _sPadlock = new();
+    private static readonly object SPadlock = new();
 
     public static TestFactory Instance
     {
@@ -37,7 +37,7 @@ public sealed class TestFactory : WebApplicationFactory<Program>
         {
             if (_sInstance == null)
             {
-                lock (_sPadlock)
+                lock (SPadlock)
                 {
                     if (_sInstance == null)
                     {
@@ -183,11 +183,11 @@ public sealed class TestFactory : WebApplicationFactory<Program>
 
     private static string GetTestLocalDbConnectionString(string projectDir)
     {
-        const string DbName = "ProjectPortalIntegrationTestsDB2";
-        var dbPath = Path.Combine(projectDir, $"{DbName}.mdf");
+        const string dbName = "ProjectPortalIntegrationTestsDB2";
+        var dbPath = Path.Combine(projectDir, $"{dbName}.mdf");
 
         // Set Initial Catalog to be able to delete database!
-        return $"Server=(LocalDB)\\MSSQLLocalDB;Initial Catalog={DbName};Integrated Security=true;AttachDbFileName={dbPath}";
+        return $"Server=(LocalDB)\\MSSQLLocalDB;Initial Catalog={dbName};Integrated Security=true;AttachDbFileName={dbPath}";
     }
 
     //private string GetSqlLiteConnectionString()


### PR DESCRIPTION
# Description

Updates the API endpoints that gives Portal Apps as list of objects:
- {portalId:guid}/apps
- {portalId:guid}/contexts/{contextId:guid}/apps

 Now instead, these endpoint returns a list of appKeys (strings).

The old ones: 
- {portalId:guid}/appkeys
- {portalId:guid}/contexts/{contextId:guid}/appkeys

are now identical, and are deprecated and will be removed when front-end has adopted the updated endpoints.

In addition some refactoring has been done. As a result, compiler warnings has been greatly reduced

<!-- Please include a summary of the change and which issue is fixed.
List any external dependencies that are required for this change. -->

- [x] PR title and description are to the point and understandable
- [x] I have performed a self-review of my own code'

Please select version type the purposed change:
- [x] major
- [ ] minor
- [ ] patch
- [ ] none <!--- Creates an empty changeset --> 

External Relations
- [ ] database migration


## Changeset

BREAKING CHANGE: 

Updates the API endpoints that gives Portal Apps as list of objects:

{portalId:guid}/apps
{portalId:guid}/contexts/{contextId:guid}/apps
Now instead, these endpoint returns a list of appKeys (strings).

The old ones:

{portalId:guid}/appkeys
{portalId:guid}/contexts/{contextId:guid}/appkeys
are now identical, and are deprecated and will be removed when front-end has adopted the updated endpoints.

In addition some refactoring has been done. As a result, compiler warnings has been greatly reduced