### PR TITLE
feat: Add information about whether an app is found in Fusion

### DIFF
--- a/.changeset/pr-897-2237253494.md
+++ b/.changeset/pr-897-2237253494.md
@@ -1,0 +1,5 @@
+
+---
+"fusion-project-portal": minor
+--- 
+- OnboardedApp: Added a new field about whether an app is found in Fusion or not.

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/OnboardedApps/OnboardedAppDto.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Queries/OnboardedApps/OnboardedAppDto.cs
@@ -11,7 +11,9 @@ public class OnboardedAppDto : AuditDto, IMapFrom<Domain.Entities.OnboardedApp>
     public string? DisplayName { get; set; }
     public string? Description { get; set; }
     public App? AppInformation { get; set; }
+    public bool DoesNotExistInFusion { get; set; } = false;
     public List<ContextTypeDto> ContextTypes { get; set; } = [];
+    // existsInFusion
 
     public void SupplyWithFusionData(App app)
     {

--- a/backend/src/Equinor.ProjectExecutionPortal.Application/Services/AppService/AppService.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.Application/Services/AppService/AppService.cs
@@ -21,6 +21,10 @@ public class AppService : IAppService
         {
             onboardedApp.SupplyWithFusionData(fusionApp);
         }
+        else
+        {
+            onboardedApp.DoesNotExistInFusion = true;
+        }
 
         return onboardedApp;
     }
@@ -44,6 +48,10 @@ public class AppService : IAppService
         if (fusionApp != null)
         {
             onboardedApp.SupplyWithFusionData(fusionApp);
+        }
+        else
+        {
+            onboardedApp.DoesNotExistInFusion = true;
         }
     }
 }

--- a/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/OnboardedApp/ApiOnboardedApp.cs
+++ b/backend/src/Equinor.ProjectExecutionPortal.WebApi/ViewModels/OnboardedApp/ApiOnboardedApp.cs
@@ -19,6 +19,7 @@ public class ApiOnboardedApp : ApiAudit
         Description = onboardedAppDto.AppInformation?.Description;
         Contexts = onboardedAppDto.ContextTypes.Select(x => new ApiContextType(x)).ToList();
         ContextTypes = onboardedAppDto.ContextTypes.Select(x => x.ContextTypeKey).ToList();
+        DoesNotExistInFusion = onboardedAppDto.DoesNotExistInFusion;
         SupplyAudit(onboardedAppDto);
     }
 
@@ -28,4 +29,5 @@ public class ApiOnboardedApp : ApiAudit
     public string? Description { get; set; }
     public List<ApiContextType> Contexts { get; set; } = [];
     public List<string> ContextTypes { get; set; } = [];
+    public bool DoesNotExistInFusion { get; set; }
 }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed.
List any external dependencies that are required for this change. -->

Added a new field about whether an app is found in Fusion or not.

Field name: DoesNotExistInFusion (bool)
Upon resolving app, this field will be set conditionally

- [ ] PR title and description are to the point and understandable
- [ ] I have performed a self-review of my own code'

Please select version type the purposed change:
- [ ] major
- [x] minor
- [ ] patch
- [ ] none <!--- Creates an empty changeset --> 

External Relations
- [ ] database migration


## Changeset

<!--- Write your changeset here -->

- OnboardedApp: Added a new field about whether an app is found in Fusion or not.